### PR TITLE
gitignoring tsconfig.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 .project
 .idea
+tsconfig.tsbuildinfo


### PR DESCRIPTION
Not needed as it stores incremental compilation information to speed up composite projects builds (see [TS Build Info File documentation section](https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile)).

