### PR TITLE
Get rid of typescript runtime dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@
 import {createConfiguration} from "./command-line.js";
 import {createMcpServer} from "./mcp-server.js";
 import {debug} from "./debug.js";
+// Ensure Zod is included in the bundle
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { z } from 'zod';
 
 const configuration = createConfiguration();
 const serverName = "mcp-server";

--- a/src/ts.ts
+++ b/src/ts.ts
@@ -1,9 +1,0 @@
-import * as ts from "typescript";
-import { z } from 'zod';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function evalTS(code:string): any {
-    // Create a function that includes z in its scope
-    const evalFunction = new Function('z', `return ${ts.transpile(code)}`);
-    return evalFunction(z);
-}

--- a/tests/ts.test.ts
+++ b/tests/ts.test.ts
@@ -1,5 +1,0 @@
-import { evalTS } from '../src/ts';
-
-test('evalTS', () => {
-    expect(evalTS("1 + 2")).toEqual(3);
-});


### PR DESCRIPTION
- Get rid of `evalTS` function
- Ensure `zod` is bundled in the package by adding the appropriate import statement directly in index.ts