### PR TITLE
Move typescript from development to runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "axios": "^1.10.0",
     "commander": "^14.0.0",
     "json-schema-to-zod": "^2.6.1",
-    "openapi-types": "^12.1.3"
+    "openapi-types": "^12.1.3",
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.27.1",
@@ -37,7 +38,6 @@
     "nock": "^14.0.7",
     "nodemon": "^3.1.10",
     "ts-jest": "^29.4.0",
-    "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0"
   },
   "type": "module",


### PR DESCRIPTION
- We do not want to implement our own mapping from json-schema to zod  mapping; so we keep  [json-schema-to-zod](https://www.npmjs.com/package/json-schema-to-zod) .
- Thus we need typescript at runtime