### PR TITLE
0.0.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "di-mcp-server",
-  "version": "0.0.33",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "di-mcp-server",
-      "version": "0.0.33",
+      "version": "0.0.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "di-mcp-server",
-  "version": "0.0.33",
+  "version": "0.0.35",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Previous release `0.0.34` was made without incrementing the version :
 - https://github.com/DecisionsDev/decision-intelligence-mcp-server/releases/tag/0.0.34
