### PR TITLE
0.0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "di-mcp-server",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Overwrite `0.0.35` release, previously published to npmjs but not properly packaged.